### PR TITLE
Color assets + extension to call them + Rootstrap color palette

### DIFF
--- a/swift-ui-base/Assets.xcassets/Palette/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsBlue.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "247",
+          "green" : "54",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.969",
+          "green" : "0.212",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsDarkGray.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsDarkGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "131",
+          "green" : "129",
+          "red" : "128"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.514",
+          "green" : "0.506",
+          "red" : "0.502"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsGreen.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsGreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "133",
+          "green" : "187",
+          "red" : "44"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.522",
+          "green" : "0.733",
+          "red" : "0.173"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsLightGray.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsLightGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "184",
+          "green" : "181",
+          "red" : "181"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.722",
+          "green" : "0.710",
+          "red" : "0.710"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsPink.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsPink.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "142",
+          "green" : "145",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.557",
+          "green" : "0.569",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsRed.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "49",
+          "green" : "64",
+          "red" : "207"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.192",
+          "green" : "0.251",
+          "red" : "0.812"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsWhite.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "245",
+          "green" : "242",
+          "red" : "241"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.961",
+          "green" : "0.949",
+          "red" : "0.945"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsYellow.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/Rootstrap/rsYellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "57",
+          "green" : "230",
+          "red" : "234"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.224",
+          "green" : "0.902",
+          "red" : "0.918"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/altoGray.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/altoGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "216",
+          "green" : "216",
+          "red" : "216"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.847",
+          "green" : "0.847",
+          "red" : "0.847"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/athensGray.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/athensGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "237",
+          "green" : "221",
+          "red" : "229"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.929",
+          "green" : "0.867",
+          "red" : "0.898"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/cadetBlue.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/cadetBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "199",
+          "green" : "175",
+          "red" : "167"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.780",
+          "green" : "0.686",
+          "red" : "0.655"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/darkGray.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/darkGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "79",
+          "green" : "61",
+          "red" : "54"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.310",
+          "green" : "0.239",
+          "red" : "0.212"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Assets.xcassets/Palette/errorRed.colorset/Contents.json
+++ b/swift-ui-base/Assets.xcassets/Palette/errorRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.318",
+          "green" : "0.318",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.318",
+          "green" : "0.318",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-ui-base/Common/View/TextField/View/TextFieldView.swift
+++ b/swift-ui-base/Common/View/TextField/View/TextFieldView.swift
@@ -18,7 +18,7 @@ struct TextFieldView: View {
         Text(fieldData.title)
           .frame(maxWidth: .infinity, alignment: .leading)
           .font(Font.headline.weight(.regular))
-          .foregroundColor(.lightGray)
+          .foregroundColor(.cadetBlue)
           .offset(CGSize(width: 0, height: fieldData.isEmpty ? 0 : -30))
           .opacity(fieldData.isEmpty ? 0.7 : 1)
           .animation(.easeOut(duration: 0.2))
@@ -41,7 +41,7 @@ struct TextFieldView: View {
       Rectangle()
         .frame(maxWidth: .infinity, maxHeight: 1)
         .foregroundColor(
-          !fieldData.isEmpty && !fieldData.isValid ? .errorRed : .lightGray
+          !fieldData.isEmpty && !fieldData.isValid ? .errorRed : .cadetBlue
         )
         .opacity(0.5)
       

--- a/swift-ui-base/Extensions/ColorExtension.swift
+++ b/swift-ui-base/Extensions/ColorExtension.swift
@@ -7,27 +7,12 @@
 //
 
 import SwiftUI
-import Foundation
 
 extension Color {
   
-  static let darkGray = UIColor(red: 54, green: 61, blue: 79).asColor()
-  static let athensGray = UIColor(red: 229, green: 231, blue: 237).asColor()
-  static let altoGray = UIColor(red: 216, green: 216, blue: 216).asColor()
-  static let cadetBlue = UIColor(red: 167, green: 175, blue: 199).asColor()
-  static let lightGray = UIColor(red: 167, green: 175, blue: 199).asColor()
-  static let errorRed = UIColor(red: 255, green: 81, blue: 82).asColor()
-}
-
-extension UIColor {
-  convenience init(red: Int, green: Int, blue: Int) {
-    self.init(red: min(CGFloat(red), 255.0) / 255.0,
-              green: min(CGFloat(green), 255.0) / 255.0,
-              blue: min(CGFloat(blue), 255.0) / 255.0,
-              alpha: 1.0)
-  }
-  
-  func asColor() -> Color {
-    return Color(self)
-  }
+  static let darkGray = Color("darkGray")
+  static let athensGray = Color("athensGray")
+  static let altoGray = Color("altoGray")
+  static let cadetBlue = Color("cadetBlue")
+  static let errorRed = Color("errorRed")
 }


### PR DESCRIPTION
#### Description

* Color assets
* Extension to call them
* Rootstrap color palette anticipating dark mode (next PR)

---

#### Preview

<img width="227" alt="Screen Shot 2020-07-30 at 5 31 25 PM" src="https://user-images.githubusercontent.com/1467868/88971571-882a1300-d28a-11ea-8349-deb568c47387.png">